### PR TITLE
Fix small typo that caused gradle errors in case-sensitive filesystems

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,6 @@ dependencyResolutionManagement {
         maven { url 'https://jitpack.io' }
     }
 }
-rootProject.name = "AndroidLibraw"
+rootProject.name = "AndroidLibRaw"
 include ':app'
 include ':libraw'


### PR DESCRIPTION
Was just testing out this library in WSL on a Windows 11 NTFS volume and noticed this tiny thing. Figured I would just contribute it back since I already have it on my local, and it might help someone else :)