### PR TITLE
Allow easy reading of white balance settings from camera with color temps

### DIFF
--- a/libraw/src/main/cpp/anrdroidraw.cpp
+++ b/libraw/src/main/cpp/anrdroidraw.cpp
@@ -92,7 +92,7 @@ extern "C" JNIEXPORT jobjectArray JNICALL Java_com_homesoft_photo_libraw_LibRaw_
     auto outerArray = env->NewObjectArray(arraySize, floatArrayClass, initial);
     for (int i=0; i < arraySize; i++) {
         auto floatArray = env->NewFloatArray(subarraySize);
-        // color temp, r, g, b, g1
+        // color temp, r, g1, b, g2
         env->SetFloatArrayRegion(floatArray, 0, subarraySize, libRaw->imgdata.color.WBCT_Coeffs[i]);
         env->SetObjectArrayElement(outerArray, i, floatArray);
         env->DeleteLocalRef(floatArray);

--- a/libraw/src/main/cpp/anrdroidraw.cpp
+++ b/libraw/src/main/cpp/anrdroidraw.cpp
@@ -74,6 +74,63 @@ extern "C" JNIEXPORT jint JNICALL Java_com_homesoft_photo_libraw_LibRaw_getRight
 extern "C" JNIEXPORT jint JNICALL Java_com_homesoft_photo_libraw_LibRaw_getOrientation(JNIEnv* env, jobject jLibRaw){
     return getLibRaw(env, jLibRaw)->imgdata.sizes.flip;
 }
+
+extern "C" JNIEXPORT jfloatArray JNICALL Java_com_homesoft_photo_libraw_LibRaw_getCameraMul(JNIEnv* env, jobject jLibRaw) {
+    auto floatArray = env->NewFloatArray(4);
+    auto cam_mul = getLibRaw(env, jLibRaw)->imgdata.color.cam_mul;
+    env->SetFloatArrayRegion(floatArray, 0, 4, cam_mul);
+    return floatArray;
+}
+
+extern "C" JNIEXPORT jobjectArray JNICALL Java_com_homesoft_photo_libraw_LibRaw_getWhiteBalanceCoefficientsWithTemps(JNIEnv* env, jobject jLibRaw) {
+    auto libRaw = getLibRaw(env, jLibRaw);
+    int elementSize = sizeof(libRaw->imgdata.color.WBCT_Coeffs[0][0]);
+    int firstRowSize = sizeof(libRaw->imgdata.color.WBCT_Coeffs[0]) / elementSize;
+    const int arraySize = sizeof(libRaw->imgdata.color.WBCT_Coeffs) / elementSize / firstRowSize;
+    const int subarraySize = firstRowSize;
+    auto initial = env->NewFloatArray(subarraySize);
+
+    auto floatArrayClass = env->FindClass("[F");
+    if (floatArrayClass == nullptr) {
+        return nullptr;
+    }
+    auto outerArray = env->NewObjectArray(arraySize, floatArrayClass, initial);
+    for (int i=0; i < arraySize; i++) {
+        auto floatArray = env->NewFloatArray(subarraySize);
+        // color temp, r, g, b, g1
+        env->SetFloatArrayRegion(floatArray, 0, subarraySize, libRaw->imgdata.color.WBCT_Coeffs[i]);
+        env->SetObjectArrayElement(outerArray, i, floatArray);
+        env->DeleteLocalRef(floatArray);
+    }
+
+    return outerArray;
+}
+
+extern "C" JNIEXPORT jobjectArray JNICALL Java_com_homesoft_photo_libraw_LibRaw_getWhiteBalanceCoefficients(JNIEnv* env, jobject jLibRaw) {
+    auto libRaw = getLibRaw(env, jLibRaw);
+    int elementSize = sizeof(libRaw->imgdata.color.WB_Coeffs[0][0]);
+    int firstRowSize = sizeof(libRaw->imgdata.color.WB_Coeffs[0]) / elementSize;
+    const int arraySize = sizeof(libRaw->imgdata.color.WB_Coeffs) / firstRowSize / elementSize;
+    const int subarraySize = firstRowSize;
+    auto initial = env->NewIntArray(subarraySize);
+
+    auto intArrayClass = env->FindClass("[I");
+    if (intArrayClass == nullptr) {
+        return nullptr;
+    }
+    auto outerArray = env->NewObjectArray(arraySize, intArrayClass, initial);
+    for (int i=0; i < arraySize; i++) {
+        auto intArray = env->NewIntArray(subarraySize);
+        // color temp, r, g, b, g1
+        env->SetIntArrayRegion(intArray, 0, subarraySize, libRaw->imgdata.color.WB_Coeffs[i]);
+        env->SetObjectArrayElement(outerArray, i, intArray);
+        env->DeleteLocalRef(intArray);
+    }
+
+    return outerArray;
+}
+
+
 extern "C" JNIEXPORT void JNICALL Java_com_homesoft_photo_libraw_LibRaw_setOrientation(JNIEnv* env, jobject jLibRaw, int orientation){
     getLibRaw(env, jLibRaw)->imgdata.params.user_flip = orientation;
 }

--- a/libraw/src/main/cpp/anrdroidraw.cpp
+++ b/libraw/src/main/cpp/anrdroidraw.cpp
@@ -84,16 +84,11 @@ extern "C" JNIEXPORT jfloatArray JNICALL Java_com_homesoft_photo_libraw_LibRaw_g
 
 extern "C" JNIEXPORT jobjectArray JNICALL Java_com_homesoft_photo_libraw_LibRaw_getWhiteBalanceCoefficientsWithTemps(JNIEnv* env, jobject jLibRaw) {
     auto libRaw = getLibRaw(env, jLibRaw);
-    int elementSize = sizeof(libRaw->imgdata.color.WBCT_Coeffs[0][0]);
-    int firstRowSize = sizeof(libRaw->imgdata.color.WBCT_Coeffs[0]) / elementSize;
-    const int arraySize = sizeof(libRaw->imgdata.color.WBCT_Coeffs) / elementSize / firstRowSize;
-    const int subarraySize = firstRowSize;
+    const int arraySize = 64;
+    const int subarraySize = 5;
     auto initial = env->NewFloatArray(subarraySize);
 
     auto floatArrayClass = env->FindClass("[F");
-    if (floatArrayClass == nullptr) {
-        return nullptr;
-    }
     auto outerArray = env->NewObjectArray(arraySize, floatArrayClass, initial);
     for (int i=0; i < arraySize; i++) {
         auto floatArray = env->NewFloatArray(subarraySize);
@@ -108,20 +103,15 @@ extern "C" JNIEXPORT jobjectArray JNICALL Java_com_homesoft_photo_libraw_LibRaw_
 
 extern "C" JNIEXPORT jobjectArray JNICALL Java_com_homesoft_photo_libraw_LibRaw_getWhiteBalanceCoefficients(JNIEnv* env, jobject jLibRaw) {
     auto libRaw = getLibRaw(env, jLibRaw);
-    int elementSize = sizeof(libRaw->imgdata.color.WB_Coeffs[0][0]);
-    int firstRowSize = sizeof(libRaw->imgdata.color.WB_Coeffs[0]) / elementSize;
-    const int arraySize = sizeof(libRaw->imgdata.color.WB_Coeffs) / firstRowSize / elementSize;
-    const int subarraySize = firstRowSize;
+    const int arraySize = 256;
+    const int subarraySize = 4;
     auto initial = env->NewIntArray(subarraySize);
 
     auto intArrayClass = env->FindClass("[I");
-    if (intArrayClass == nullptr) {
-        return nullptr;
-    }
     auto outerArray = env->NewObjectArray(arraySize, intArrayClass, initial);
     for (int i=0; i < arraySize; i++) {
         auto intArray = env->NewIntArray(subarraySize);
-        // color temp, r, g, b, g1
+        // r, g1, b, g2
         env->SetIntArrayRegion(intArray, 0, subarraySize, libRaw->imgdata.color.WB_Coeffs[i]);
         env->SetObjectArrayElement(outerArray, i, intArray);
         env->DeleteLocalRef(intArray);

--- a/libraw/src/main/java/com/homesoft/photo/libraw/LibRaw.java
+++ b/libraw/src/main/java/com/homesoft/photo/libraw/LibRaw.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Derived from https://github.com/TSGames/Libraw-Android/blob/master/app/src/main/java/com/tssystems/Libraw.java
@@ -128,7 +127,7 @@ public class LibRaw implements AutoCloseable {
 
     /**
      * getAvailableWhiteBalanceCoefficients filters out unfilled values in getWhiteBalanceCoefficients
-     * @return an array of non-zero white balance coefficients
+     * @return a List of non-zero white balance coefficients
      */
     public List<int[]> getAvailableWhiteBalanceCoefficients() {
         final ArrayList<int[]> wbList = new ArrayList<>();
@@ -148,7 +147,7 @@ public class LibRaw implements AutoCloseable {
     /**
      * getAvailableWhiteBalanceCtCoefficients filters out unfilled values in getWhiteBalanceCoefficients
      * and places them in a map.
-     * @return a map of color temperature in kelvin to white balance coefficients
+     * @return a Map of color temperature in kelvin to white balance coefficients
      */
     public Map<Float, float[]> getAvailableWhiteBalanceCtCoefficients() {
         final float[][] tempCoefficients = getWhiteBalanceCoefficientsWithTemps();

--- a/libraw/src/main/java/com/homesoft/photo/libraw/LibRaw.java
+++ b/libraw/src/main/java/com/homesoft/photo/libraw/LibRaw.java
@@ -149,7 +149,7 @@ public class LibRaw implements AutoCloseable {
      * and places them in a map.
      * @return a Map of color temperature in kelvin to white balance coefficients
      */
-    public Map<Float, float[]> getAvailableWhiteBalanceCtCoefficients() {
+    public Map<Float, float[]> getAvailableWhiteBalanceCoefficientsWithTemps() {
         final float[][] tempCoefficients = getWhiteBalanceCoefficientsWithTemps();
         final HashMap<Float, float[]> wbList = new HashMap<>();
         if (tempCoefficients != null) {


### PR DESCRIPTION
Well, this didn't actually end up helping me (the raw files I'm working with don't have white balance multipliers pre-set), but I figured it might help someone.

This reads and nicely formats a set of white balance multipliers and includes color temp info alongside it.

Testing with camera raw file from Fuji X-Pro 2, got the following results:
![Screenshot 2024-04-10 172701](https://github.com/dburckh/AndroidLibRaw/assets/642994/25ca5b09-6522-47fd-b84c-1d9636c87e58)

[_DSF5079.zip](https://github.com/dburckh/AndroidLibRaw/files/14939219/_DSF5079.zip)

(zip contains tested raw file)

please go ahead and feel free to modify this in keeping with the style of the project :)